### PR TITLE
Exclude url assets by default

### DIFF
--- a/config/nova-package-bundler-command.php
+++ b/config/nova-package-bundler-command.php
@@ -19,6 +19,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Download url assets
+    |--------------------------------------------------------------------------
+    |
+    | Set this value to `true` if you want the bundler command to download
+    | assets where the path is already a url. When `false`, url assets are
+    | ignored when bundling and nova will load them as normal.
+    |
+    */
+    'download_url_assets' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Excluded assets
     |--------------------------------------------------------------------------
     |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,21 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Fidum\\\\NovaPackageBundler\\\\Services\\\\ScriptAssetService\\:\\:allowed\\(\\) should return Fidum\\\\NovaPackageBundler\\\\Contracts\\\\Collections\\\\AssetCollection but returns Illuminate\\\\Support\\\\Enumerable\\<int, mixed\\>\\.$#"
+			count: 1
+			path: src/Services/ScriptAssetService.php
+
+		-
+			message: "#^Method Fidum\\\\NovaPackageBundler\\\\Services\\\\ScriptAssetService\\:\\:excluded\\(\\) should return Fidum\\\\NovaPackageBundler\\\\Contracts\\\\Collections\\\\AssetCollection but returns Illuminate\\\\Support\\\\Enumerable\\<int, mixed\\>\\.$#"
+			count: 1
+			path: src/Services/ScriptAssetService.php
+
+		-
+			message: "#^Method Fidum\\\\NovaPackageBundler\\\\Services\\\\StyleAssetService\\:\\:allowed\\(\\) should return Fidum\\\\NovaPackageBundler\\\\Contracts\\\\Collections\\\\AssetCollection but returns Illuminate\\\\Support\\\\Enumerable\\<int, mixed\\>\\.$#"
+			count: 1
+			path: src/Services/StyleAssetService.php
+
+		-
+			message: "#^Method Fidum\\\\NovaPackageBundler\\\\Services\\\\StyleAssetService\\:\\:excluded\\(\\) should return Fidum\\\\NovaPackageBundler\\\\Contracts\\\\Collections\\\\AssetCollection but returns Illuminate\\\\Support\\\\Enumerable\\<int, mixed\\>\\.$#"
+			count: 1
+			path: src/Services/StyleAssetService.php

--- a/src/Collections/AssetCollection.php
+++ b/src/Collections/AssetCollection.php
@@ -3,18 +3,17 @@
 namespace Fidum\NovaPackageBundler\Collections;
 
 use Fidum\NovaPackageBundler\Contracts\Collections\AssetCollection as AssetCollectionContract;
-use Fidum\NovaPackageBundler\Contracts\Filters\Filter;
 use Illuminate\Support\Collection;
 
 class AssetCollection extends Collection implements AssetCollectionContract
 {
-    public function applyFilter(Filter $filter): AssetCollectionContract
+    public function applyFilters(\Fidum\NovaPackageBundler\Contracts\Collections\FilterCollection $filters): AssetCollectionContract
     {
-        return $this->filter($filter->apply(...));
+        return $this->filter($filters->apply(...));
     }
 
-    public function rejectFilter(Filter $filter): AssetCollectionContract
+    public function rejectFilters(\Fidum\NovaPackageBundler\Contracts\Collections\FilterCollection $filters): AssetCollectionContract
     {
-        return $this->reject($filter->apply(...));
+        return $this->reject($filters->apply(...));
     }
 }

--- a/src/Collections/FilterCollection.php
+++ b/src/Collections/FilterCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Fidum\NovaPackageBundler\Collections;
+
+use Fidum\NovaPackageBundler\Contracts\Collections\FilterCollection as FilterCollectionContract;
+use Fidum\NovaPackageBundler\Contracts\Filters\Filter;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Asset;
+
+class FilterCollection extends Collection implements FilterCollectionContract
+{
+    public function apply(Asset $asset): bool
+    {
+        return $this->every(function (string $filterClass) use ($asset) {
+            /** @var Filter $filter */
+            $filter = app($filterClass);
+
+            return $filter->apply($asset);
+        });
+    }
+}

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fidum\NovaPackageBundler\Commands;
 
+use Fidum\NovaPackageBundler\Concerns\IdentifiesUrls;
 use Fidum\NovaPackageBundler\Contracts\Services\AssetService;
 use Fidum\NovaPackageBundler\Contracts\Services\ScriptAssetService;
 use Fidum\NovaPackageBundler\Contracts\Services\StyleAssetService;
@@ -11,13 +12,14 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Str;
 use Laravel\Nova\Asset;
 use Laravel\Nova\Events\ServingNova;
 use Laravel\Nova\Nova;
 
 class PublishCommand extends Command
 {
+    use IdentifiesUrls;
+
     public $signature = 'nova:tools:publish';
 
     public $description = 'Combines nova styles and scripts into single asset files';
@@ -88,11 +90,6 @@ class PublishCommand extends Command
 
             $this->line('');
         }
-    }
-
-    private function isUrl(string $path): bool
-    {
-        return Str::startsWith($path, ['http://', 'https://', '://']);
     }
 
     private function readFile(string $path): ?string

--- a/src/Concerns/IdentifiesUrls.php
+++ b/src/Concerns/IdentifiesUrls.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Fidum\NovaPackageBundler\Concerns;
+
+use Illuminate\Support\Str;
+
+trait IdentifiesUrls
+{
+    private function isUrl(string $path): bool
+    {
+        return Str::startsWith($path, ['http://', 'https://', '://']);
+    }
+}

--- a/src/Contracts/Collections/AssetCollection.php
+++ b/src/Contracts/Collections/AssetCollection.php
@@ -2,12 +2,11 @@
 
 namespace Fidum\NovaPackageBundler\Contracts\Collections;
 
-use Fidum\NovaPackageBundler\Contracts\Filters\Filter;
 use Illuminate\Support\Enumerable;
 
 interface AssetCollection extends Enumerable
 {
-    public function applyFilter(Filter $filter): AssetCollection;
+    public function applyFilters(FilterCollection $filters): AssetCollection;
 
-    public function rejectFilter(Filter $filter): AssetCollection;
+    public function rejectFilters(FilterCollection $filters): AssetCollection;
 }

--- a/src/Contracts/Collections/FilterCollection.php
+++ b/src/Contracts/Collections/FilterCollection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fidum\NovaPackageBundler\Contracts\Collections;
+
+use Illuminate\Support\Enumerable;
+use Laravel\Nova\Asset;
+
+interface FilterCollection extends Enumerable
+{
+    public function apply(Asset $asset): bool;
+}

--- a/src/Contracts/Filters/SkipUrlAssetsFilter.php
+++ b/src/Contracts/Filters/SkipUrlAssetsFilter.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Fidum\NovaPackageBundler\Contracts\Filters;
+
+interface SkipUrlAssetsFilter extends Filter {}

--- a/src/Filters/SkipUrlAssetsFilter.php
+++ b/src/Filters/SkipUrlAssetsFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Fidum\NovaPackageBundler\Filters;
+
+use Fidum\NovaPackageBundler\Concerns\IdentifiesUrls;
+use Fidum\NovaPackageBundler\Contracts\Filters\SkipUrlAssetsFilter as SkipUrlAssetsFilterContract;
+use Laravel\Nova\Asset;
+
+class SkipUrlAssetsFilter implements SkipUrlAssetsFilterContract
+{
+    use IdentifiesUrls;
+
+    public function __construct(protected bool $allowed) {}
+
+    public function apply(Asset $asset): bool
+    {
+        if ($this->allowed) {
+            return true;
+        }
+
+        if ($this->isUrl($asset->path())) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/NovaPackageBundlerServiceProvider.php
+++ b/src/NovaPackageBundlerServiceProvider.php
@@ -4,7 +4,6 @@ namespace Fidum\NovaPackageBundler;
 
 use Fidum\NovaPackageBundler\Collections\FilterCollection;
 use Fidum\NovaPackageBundler\Commands\PublishCommand;
-use Fidum\NovaPackageBundler\Contracts\Collections\AssetCollection as AssetCollectionContract;
 use Fidum\NovaPackageBundler\Contracts\Collections\FilterCollection as FilterCollectionContract;
 use Fidum\NovaPackageBundler\Contracts\Filters\ScriptExcludedFilter as ScriptExcludedFilterContract;
 use Fidum\NovaPackageBundler\Contracts\Filters\SkipUrlAssetsFilter as SkipUrlAssetsFilterContract;
@@ -78,7 +77,7 @@ class NovaPackageBundlerServiceProvider extends PackageServiceProvider implement
     public function provides()
     {
         return [
-            AssetCollectionContract::class,
+            FilterCollectionContract::class,
             ScriptAssetServiceContract::class,
             ScriptExcludedFilterContract::class,
             StyleAssetServiceContract::class,

--- a/src/Services/Concerns/CollectsAllowedAssets.php
+++ b/src/Services/Concerns/CollectsAllowedAssets.php
@@ -8,6 +8,6 @@ trait CollectsAllowedAssets
 {
     public function allowed(): AssetCollectionContract
     {
-        return $this->collect()->applyFilter($this->filter)->values();
+        return $this->collect()->applyFilters($this->filters)->values();
     }
 }

--- a/src/Services/Concerns/CollectsExcludedAssets.php
+++ b/src/Services/Concerns/CollectsExcludedAssets.php
@@ -8,6 +8,6 @@ trait CollectsExcludedAssets
 {
     public function excluded(): AssetCollectionContract
     {
-        return $this->collect()->rejectFilter($this->filter)->values();
+        return $this->collect()->rejectFilters($this->filters)->values();
     }
 }

--- a/src/Services/ScriptAssetService.php
+++ b/src/Services/ScriptAssetService.php
@@ -4,7 +4,7 @@ namespace Fidum\NovaPackageBundler\Services;
 
 use Fidum\NovaPackageBundler\Collections\AssetCollection;
 use Fidum\NovaPackageBundler\Contracts\Collections\AssetCollection as AssetCollectionContract;
-use Fidum\NovaPackageBundler\Contracts\Filters\ScriptExcludedFilter as ScriptExcludedFilterContract;
+use Fidum\NovaPackageBundler\Contracts\Collections\FilterCollection;
 use Fidum\NovaPackageBundler\Contracts\Services\ScriptAssetService as ScriptAssetServiceContract;
 use Fidum\NovaPackageBundler\Services\Concerns\BuildsOutputPath;
 use Fidum\NovaPackageBundler\Services\Concerns\CollectsAllowedAssets;
@@ -18,8 +18,8 @@ class ScriptAssetService implements ScriptAssetServiceContract
     use CollectsExcludedAssets;
 
     public function __construct(
-        protected ScriptExcludedFilterContract $filter,
         protected string $outputPath,
+        protected FilterCollection $filters,
     ) {}
 
     public function collect(): AssetCollectionContract

--- a/src/Services/StyleAssetService.php
+++ b/src/Services/StyleAssetService.php
@@ -4,7 +4,7 @@ namespace Fidum\NovaPackageBundler\Services;
 
 use Fidum\NovaPackageBundler\Collections\AssetCollection;
 use Fidum\NovaPackageBundler\Contracts\Collections\AssetCollection as AssetCollectionContract;
-use Fidum\NovaPackageBundler\Contracts\Filters\StyleExcludedFilter as StyleExcludedFilterContract;
+use Fidum\NovaPackageBundler\Contracts\Collections\FilterCollection;
 use Fidum\NovaPackageBundler\Contracts\Services\StyleAssetService as StyleAssetServiceContract;
 use Fidum\NovaPackageBundler\Services\Concerns\BuildsOutputPath;
 use Fidum\NovaPackageBundler\Services\Concerns\CollectsAllowedAssets;
@@ -18,8 +18,8 @@ class StyleAssetService implements StyleAssetServiceContract
     use CollectsExcludedAssets;
 
     public function __construct(
-        protected StyleExcludedFilterContract $filter,
         protected string $outputPath,
+        protected FilterCollection $filters,
     ) {}
 
     public function collect(): AssetCollectionContract

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_downloads_url_assets_when_enabled.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_downloads_url_assets_when_enabled.snap
@@ -1,0 +1,4 @@
+/** Test JS content **/
+/** Public JS content **/
+/** Remote URL JS content **/
+/** Tool JS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_downloads_url_assets_when_enabled__2.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_downloads_url_assets_when_enabled__2.snap
@@ -1,0 +1,4 @@
+/** Test CSS content **/
+/** Public CSS content **/
+/** Remote URL CSS content **/
+/** Tool CSS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles.snap
@@ -1,4 +1,0 @@
-/** Test JS content **/
-/** Public JS content **/
-/** Remote URL JS content **/
-/** Tool JS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles.snap
@@ -1,0 +1,3 @@
+/** Test JS content **/
+/** Public JS content **/
+/** Tool JS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles__2.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles__2.snap
@@ -1,0 +1,3 @@
+/** Test CSS content **/
+/** Public CSS content **/
+/** Tool CSS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles__2.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles__2.snap
@@ -1,4 +1,0 @@
-/** Test CSS content **/
-/** Public CSS content **/
-/** Remote URL CSS content **/
-/** Tool CSS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets.snap
@@ -1,0 +1,2 @@
+/** Test JS content **/
+/** Public JS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets.snap
@@ -1,3 +1,0 @@
-/** Test JS content **/
-/** Public JS content **/
-/** Remote URL JS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets__2.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets__2.snap
@@ -1,0 +1,2 @@
+/** Test CSS content **/
+/** Public CSS content **/

--- a/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets__2.snap
+++ b/tests/.pest/snapshots/Commands/PublishCommandTest/it_finds_and_bundles_registered_scripts_and_styles_and_excludes_configured_assets__2.snap
@@ -1,3 +1,0 @@
-/** Test CSS content **/
-/** Public CSS content **/
-/** Remote URL CSS content **/

--- a/tests/Commands/PublishCommandTest.php
+++ b/tests/Commands/PublishCommandTest.php
@@ -43,6 +43,19 @@ it('finds and bundles registered scripts and styles', function () {
 
     assertFileContent(public_path('/vendor/nova-tools/app.js'));
     assertFileContent(public_path('/vendor/nova-tools/app.css'));
+    Http::assertSentCount(0);
+});
+
+it('downloads url assets when enabled', function () {
+    config()->set('nova-package-bundler-command.download_url_assets', true);
+    expect(public_path())->toBe('tests'.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'public');
+
+    artisan('nova:tools:publish')
+        ->assertSuccessful()
+        ->execute();
+
+    assertFileContent(public_path('/vendor/nova-tools/app.js'));
+    assertFileContent(public_path('/vendor/nova-tools/app.css'));
     assertHttpSent();
 });
 
@@ -58,7 +71,7 @@ it('finds and bundles registered scripts and styles and excludes configured asse
 
     assertFileContent(public_path('/vendor/nova-tools/app.js'));
     assertFileContent(public_path('/vendor/nova-tools/app.css'));
-    assertHttpSent();
+    Http::assertSentCount(0);
 });
 
 afterEach(function () {

--- a/tests/Http/Middleware/OverrideNovaPackagesMiddlewareTest.php
+++ b/tests/Http/Middleware/OverrideNovaPackagesMiddlewareTest.php
@@ -58,7 +58,7 @@ it('keeps configured assets that we excluded from the bundle', function () {
     expect(Nova::$scripts)->toHaveCount(3)
         ->and(Nova::$styles)->toHaveCount(3)
         ->and(Nova::$scripts[0])->path()->toEqual('https://example.com/index.js')
-        ->and(Nova::$scripts[1])->path()->toEqual(testDirectory('fixtures/input/test.css'))
+        ->and(Nova::$scripts[1])->path()->toEqual(testDirectory('fixtures/input/test.js'))
         ->and(Nova::$scripts[2])->path()->toEqual('http://localhost/vendor/nova-tools/app.js')
         ->and(Nova::$styles[0])->path()->toEqual('https://example.com/app.css')
         ->and(Nova::$styles[1])->path()->toEqual(testDirectory('fixtures/input/test.css'))

--- a/tests/Http/Middleware/OverrideNovaPackagesMiddlewareTest.php
+++ b/tests/Http/Middleware/OverrideNovaPackagesMiddlewareTest.php
@@ -8,6 +8,8 @@ use function Pest\testDirectory;
 
 beforeEach(function () {
     $this->app->setBasePath(testDirectory('fixtures'));
+    Nova::remoteScript('https://example.com/index.js');
+    Nova::remoteStyle('https://example.com/app.css');
     Nova::script('test-package', testDirectory('fixtures/input/test.js'));
     Nova::style('test-package', testDirectory('fixtures/input/test.css'));
     Nova::remoteScript('/input/public.js');
@@ -16,7 +18,23 @@ beforeEach(function () {
 
 it('replaces registered styles and scripts with the bundled files', function () {
     expect(public_path())->toBe('tests'.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'public');
-    expect(Nova::$scripts)->toHaveCount(2)->and(Nova::$styles)->toHaveCount(2);
+    expect(Nova::$scripts)->toHaveCount(3)->and(Nova::$styles)->toHaveCount(3);
+
+    $middleware = $this->app->make(OverrideNovaPackagesMiddleware::class);
+    $middleware->handle(request(), fn () => null);
+
+    expect(Nova::$scripts)->toHaveCount(2)
+        ->and(Nova::$styles)->toHaveCount(2)
+        ->and(Nova::$scripts[0])->path()->toEqual('https://example.com/index.js')
+        ->and(Nova::$scripts[1])->path()->toEqual('http://localhost/vendor/nova-tools/app.js')
+        ->and(Nova::$styles[0])->path()->toEqual('https://example.com/app.css')
+        ->and(Nova::$styles[1])->path()->toEqual('http://localhost/vendor/nova-tools/app.css');
+});
+
+it('keeps url assets that were excluded from the bundle', function () {
+    config()->set('nova-package-bundler-command.download_url_assets', true);
+    expect(public_path())->toBe('tests'.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'public');
+    expect(Nova::$scripts)->toHaveCount(3)->and(Nova::$styles)->toHaveCount(3);
 
     $middleware = $this->app->make(OverrideNovaPackagesMiddleware::class);
     $middleware->handle(request(), fn () => null);
@@ -27,9 +45,9 @@ it('replaces registered styles and scripts with the bundled files', function () 
         ->and(Nova::$styles[0])->path()->toEqual('http://localhost/vendor/nova-tools/app.css');
 });
 
-it('replaces registered styles and scripts with the bundled files and excluded assets', function () {
+it('keeps configured assets that we excluded from the bundle', function () {
     expect(public_path())->toBe('tests'.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'public');
-    expect(Nova::$scripts)->toHaveCount(2)->and(Nova::$styles)->toHaveCount(2);
+    expect(Nova::$scripts)->toHaveCount(3)->and(Nova::$styles)->toHaveCount(3);
 
     Config::set('nova-package-bundler-command.excluded.scripts', ['test-package']);
     Config::set('nova-package-bundler-command.excluded.styles', ['test-package']);
@@ -37,12 +55,14 @@ it('replaces registered styles and scripts with the bundled files and excluded a
     $middleware = $this->app->make(OverrideNovaPackagesMiddleware::class);
     $middleware->handle(request(), fn () => null);
 
-    expect(Nova::$scripts)->toHaveCount(2)
-        ->and(Nova::$styles)->toHaveCount(2)
-        ->and(Nova::$scripts[0])->path()->toEqual(str_replace('/', DIRECTORY_SEPARATOR, 'tests/fixtures/input/test.js'))
-        ->and(Nova::$scripts[1])->path()->toEqual('http://localhost/vendor/nova-tools/app.js')
-        ->and(Nova::$styles[0])->path()->toEqual(str_replace('/', DIRECTORY_SEPARATOR, 'tests/fixtures/input/test.css'))
-        ->and(Nova::$styles[1])->path()->toEqual('http://localhost/vendor/nova-tools/app.css');
+    expect(Nova::$scripts)->toHaveCount(3)
+        ->and(Nova::$styles)->toHaveCount(3)
+        ->and(Nova::$scripts[0])->path()->toEqual('https://example.com/index.js')
+        ->and(Nova::$scripts[1])->path()->toEqual(str_replace('/', DIRECTORY_SEPARATOR, 'tests/fixtures/input/test.js'))
+        ->and(Nova::$scripts[2])->path()->toEqual('http://localhost/vendor/nova-tools/app.js')
+        ->and(Nova::$styles[0])->path()->toEqual('https://example.com/app.css')
+        ->and(Nova::$styles[1])->path()->toEqual(str_replace('/', DIRECTORY_SEPARATOR, 'tests/fixtures/input/test.css'))
+        ->and(Nova::$styles[2])->path()->toEqual('http://localhost/vendor/nova-tools/app.css');
 });
 
 afterEach(function () {


### PR DESCRIPTION
Adds a `download_url_assets` config option that defaults to `false`. 

Set this to `true` if you want the bundler command to download assets that are already remote urls.