### PR TITLE
Add support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "laravel/nova": "^4.22|^5.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },


### PR DESCRIPTION
This pull request makes a minor update to the `composer.json` file by expanding the supported versions of the `illuminate/contracts` dependency.

- Dependency compatibility:
  * Updated the `illuminate/contracts` version constraint to include support for version 13.x, in addition to 11.x and 12.x.